### PR TITLE
refactor: replace INVOICED status with DELIVERED and improve code for…

### DIFF
--- a/app/Enums/RegisterStatusEnum.php
+++ b/app/Enums/RegisterStatusEnum.php
@@ -1,14 +1,17 @@
 <?php
+
 namespace App\Enums;
 
-enum RegisterStatusEnum: string {
-    case COLLECTED           = 'collected';
-    case PAID                = 'paid';
-    case INVOICED            = 'invoiced';
-    case PENDING             = 'pending';
-    case CANCELLED           = 'cancelled';
-    case AVAILABLE           = 'available';
+enum RegisterStatusEnum: string
+{
+    case COLLECTED = 'collected';
+    case PAID = 'paid';
+    case DELIVERED = 'delivered';
+    case PENDING = 'pending';
+    case CANCELLED = 'cancelled';
+    case AVAILABLE = 'available';
     case PENDING_DAILY_RATES = 'pending daily rates';
+    case INVOICED = 'invoiced';
 
     public function label(): string
     {
@@ -16,10 +19,11 @@ enum RegisterStatusEnum: string {
             self::PENDING => 'Pending',
             self::COLLECTED => 'Collected',
             self::PAID => 'Paid',
-            self::INVOICED => 'Invoiced',
+            self::DELIVERED => 'Delivered',
             self::CANCELLED => 'Cancelled',
             self::AVAILABLE => 'Available',
-            self::PENDING_DAILY_RATES => 'Pending daily rates'
+            self::PENDING_DAILY_RATES => 'Pending daily rates',
+            self::INVOICED => 'Invoiced'
         };
     }
 
@@ -29,10 +33,11 @@ enum RegisterStatusEnum: string {
             self::PENDING => 'Pendente',
             self::COLLECTED => 'Coletado',
             self::PAID => 'Pago',
-            self::INVOICED => 'Em nota fiscal',
+            self::DELIVERED => 'Entregue',
             self::CANCELLED => 'Cancelado',
             self::AVAILABLE => 'Liberado',
             self::PENDING_DAILY_RATES => 'Pen. Diária',
+            self::INVOICED => 'Em nota fiscal',
         };
     }
 
@@ -46,7 +51,7 @@ enum RegisterStatusEnum: string {
     public static function optionsWithLabels(): array
     {
         return collect(self::cases())
-            ->mapWithKeys(fn($case) => [
+            ->mapWithKeys(fn ($case) => [
                 $case->value => $case->localizedLabel(),
             ])
             ->toArray();
@@ -58,6 +63,7 @@ enum RegisterStatusEnum: string {
             self::COLLECTED => 'collected',
             self::PAID => 'success',
             self::AVAILABLE => 'available',
+            self::DELIVERED => 'success',
             self::INVOICED => 'invoiced',
             self::PENDING => 'waiting',
             self::PENDING_DAILY_RATES => 'warning',

--- a/app/Filament/Resources/RegisterResource.php
+++ b/app/Filament/Resources/RegisterResource.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Filament\Resources;
 
 use App\Enums\RegisterStatusEnum;
@@ -90,7 +91,7 @@ class RegisterResource extends Resource
                         ->weekStartsOnSunday()
                         ->closeOnDateSelection()
                         ->live()
-                        ->beforeOrEqual(fn(Get $get) => $get('deadline_delivery') ?? null),
+                        ->beforeOrEqual(fn (Get $get) => $get('deadline_delivery') ?? null),
                     DatePicker::make('deadline_delivery')
                         ->label('Data limite entrega')
                         ->validationAttribute('Data limite entrega')
@@ -157,11 +158,12 @@ class RegisterResource extends Resource
                                 $set('destination_city', '');
                                 $set('vehicle_id', '');
                                 $set('insurance', '');
+
                                 return;
                             }
 
                             try {
-                                $extractor     = app(PdfExtractorService::class);
+                                $extractor = app(PdfExtractorService::class);
                                 $extractedData = $extractor->extractData($state->getRealPath());
 
                                 if (isset($extractedData['error'])) {
@@ -170,6 +172,7 @@ class RegisterResource extends Resource
                                         ->title('Erro na Extração')
                                         ->body($extractedData['error'])
                                         ->send();
+
                                     return;
                                 }
 
@@ -185,7 +188,7 @@ class RegisterResource extends Resource
                                         $date = Carbon::createFromFormat('d/m/Y', $extractedData['deadline_withdraw'])->format('Y-m-d');
                                         $set('deadline_withdraw', $date);
                                     } catch (Exception $e) {
-                                        Log::warning("Could not parse deadline_withdraw from PDF: " . $extractedData['deadline_withdraw']);
+                                        Log::warning('Could not parse deadline_withdraw from PDF: '.$extractedData['deadline_withdraw']);
                                     }
                                 }
                                 if (! empty($extractedData['deadline_delivery'])) {
@@ -193,14 +196,14 @@ class RegisterResource extends Resource
                                         $date = Carbon::createFromFormat('d/m/Y', $extractedData['deadline_delivery'])->format('Y-m-d');
                                         $set('deadline_delivery', $date);
                                     } catch (Exception $e) {
-                                        Log::warning("Could not parse deadline_delivery from PDF: " . $extractedData['deadline_delivery']);
+                                        Log::warning('Could not parse deadline_delivery from PDF: '.$extractedData['deadline_delivery']);
                                     }
                                 }
 
                                 if (! empty($extractedData['origin_phones'])) {
                                     $phoneString = implode(' / ', $extractedData['origin_phones']);
-                                    $notes       = $get('notes');
-                                    $set('notes', ($notes ? $notes . "\n" : '') . "Telefones Origem: " . $phoneString);
+                                    $notes = $get('notes');
+                                    $set('notes', ($notes ? $notes."\n" : '').'Telefones Origem: '.$phoneString);
                                 }
 
                                 Notification::make()
@@ -213,9 +216,9 @@ class RegisterResource extends Resource
                                 Notification::make()
                                     ->danger()
                                     ->title('Erro Inesperado')
-                                    ->body('Ocorreu um erro ao tentar extrair dados do PDF: ' . $e->getMessage())
+                                    ->body('Ocorreu um erro ao tentar extrair dados do PDF: '.$e->getMessage())
                                     ->send();
-                                Log::error("Unexpected error during PDF extraction service call: " . $e->getMessage(), ['state' => $state]);
+                                Log::error('Unexpected error during PDF extraction service call: '.$e->getMessage(), ['state' => $state]);
                             }
                         })
                         ->helperText('Faça upload do PDF para tentar preencher os campos automaticamente.'),
@@ -251,24 +254,24 @@ class RegisterResource extends Resource
 
                     Stack::make([
                         TextColumn::make('deadline_withdraw')
-                            ->label('Data limite recolha') //label just for orderBy option
+                            ->label('Data limite recolha') // label just for orderBy option
                             ->icon('heroicon-o-exclamation-triangle')
-                            ->color(fn(Register $record) => $record->deadline_withdraw?->isPast() && ! $record->isCollected() && ! $record->isCancelled() ? 'danger' : 'gray')
-                            ->tooltip(fn(Register $record) => $record->deadline_withdraw?->isPast() && ! $record->isCollected() && ! $record->isCancelled() ? 'Remoção Atrasada!' : null)
+                            ->color(fn (Register $record) => $record->deadline_withdraw?->isPast() && ! $record->isCollected() && ! $record->isCancelled() ? 'danger' : 'gray')
+                            ->tooltip(fn (Register $record) => $record->deadline_withdraw?->isPast() && ! $record->isCollected() && ! $record->isCancelled() ? 'Remoção Atrasada!' : null)
                             ->date('d/m/Y')
                             ->sortable(),
                         TextColumn::make('deadline_delivery')
-                            ->label('Data limite entrega') //label just for orderBy option
+                            ->label('Data limite entrega') // label just for orderBy option
                             ->icon('heroicon-o-calendar-days')
-                            ->color(fn(Register $record) => $record->deadline_delivery?->isPast() && ! $record->isPaid() && ! $record->isCancelled() ? 'warning' : 'gray')
-                            ->tooltip(fn(Register $record) => $record->deadline_delivery?->isPast() && ! $record->isPaid() && ! $record->isCancelled() ? 'Entrega Atrasada!' : null)
+                            ->color(fn (Register $record) => $record->deadline_delivery?->isPast() && ! $record->isPaid() && ! $record->isCollected() && ! $record->isCancelled() ? 'warning' : 'gray')
+                            ->tooltip(fn (Register $record) => $record->deadline_delivery?->isPast() && ! $record->isPaid() && ! $record->isCollected() && ! $record->isCancelled() ? 'Entrega Atrasada!' : null)
                             ->date('d/m/Y')
                             ->sortable(),
                         TextColumn::make('status')
-                            ->label('Situação') //label just for orderBy option
+                            ->label('Situação') // label just for orderBy option
                             ->badge()
-                            ->color(fn(RegisterStatusEnum $state): string => $state->color())
-                            ->formatStateUsing(fn(RegisterStatusEnum $state): string => $state->localizedLabel())
+                            ->color(fn (RegisterStatusEnum $state): string => $state->color())
+                            ->formatStateUsing(fn (RegisterStatusEnum $state): string => $state->localizedLabel())
                             ->sortable()
                             ->searchable(),
                     ]),
@@ -276,8 +279,8 @@ class RegisterResource extends Resource
                     Stack::make([
                         TextColumn::make('pdf_path')
                             ->icon('heroicon-o-document-text')
-                            ->formatStateUsing(fn($state) => 'Ver PDF')
-                            ->url(fn($record): ?string => $record->pdf_path ? Storage::disk('s3')->url($record->pdf_path) : null)
+                            ->formatStateUsing(fn ($state) => 'Ver PDF')
+                            ->url(fn ($record): ?string => $record->pdf_path ? Storage::disk('s3')->url($record->pdf_path) : null)
                             ->openUrlInNewTab(),
                     ]),
                 ]),
@@ -285,12 +288,12 @@ class RegisterResource extends Resource
                 Panel::make([
                     Stack::make([
                         TextColumn::make('driver')
-                            ->formatStateUsing(fn($state) => '<strong> Motorista: </strong>' . $state ?: '-')
+                            ->formatStateUsing(fn ($state) => '<strong> Motorista: </strong>'.$state ?: '-')
                             ->html()
                             ->icon('heroicon-o-user')
                             ->searchable(),
                         TextColumn::make('driver_plate')
-                            ->formatStateUsing(fn($state) => '<strong> Placa guincho: </strong>' . $state ?: '-')
+                            ->formatStateUsing(fn ($state) => '<strong> Placa guincho: </strong>'.$state ?: '-')
                             ->html()
                             ->icon('heroicon-o-truck')
                             ->searchable(),
@@ -302,11 +305,11 @@ class RegisterResource extends Resource
                             ->icon('heroicon-o-identification')
                             ->searchable(),
                         TextColumn::make('notes')
-                            ->formatStateUsing(fn(?string $state): ?string => $state ? '<strong>Obs.: </strong>' . nl2br(e($state)) : null)
+                            ->formatStateUsing(fn (?string $state): ?string => $state ? '<strong>Obs.: </strong>'.nl2br(e($state)) : null)
                             ->wrap()
                             ->html(),
                         TextColumn::make('value')
-                            ->formatStateUsing(fn($state) => '<strong> Valor: R$ </strong>' . str_replace('.', ',', $state))
+                            ->formatStateUsing(fn ($state) => '<strong> Valor: R$ </strong>'.str_replace('.', ',', $state))
                             ->html(),
 
                     ]),
@@ -339,26 +342,26 @@ class RegisterResource extends Resource
                         ->icon('heroicon-o-pencil-square')
                         ->form(self::getUpdateStatusFormSchema())
                         ->action(function (array $data, Collection $records): void {
-                            $records->each(fn(Register $record) => self::updateRegisterStatus($record, $data));
+                            $records->each(fn (Register $record) => self::updateRegisterStatus($record, $data));
                         })
                         ->color('primary')
                         ->modalWidth('lg')
                         ->deselectRecordsAfterCompletion(),
                 ])->label('Ações em massa'),
             ])->modifyQueryUsing(function (Builder $query) {
-            $query->orderByRaw("
+                $query->orderByRaw("
                     CASE status
                         WHEN 'pending' THEN 1
                         WHEN 'pending daily rates' THEN 2
                         WHEN 'available' THEN 3
                         WHEN 'collected' THEN 4
-                        WHEN 'invoiced' THEN 5
+                        WHEN 'delivered' THEN 5
                         WHEN 'paid' THEN 6
                         ELSE 7
                     END ASC
-                ");
-        })
-            ->recordUrl(fn(Register $record): string => static::getUrl('view', ['record' => $record]));
+                ")->orderBy('deadline_withdraw', 'asc');
+            })
+            ->recordUrl(fn (Register $record): string => static::getUrl('view', ['record' => $record]));
     }
 
     protected static function getUpdateStatusFormSchema(): array
@@ -373,16 +376,16 @@ class RegisterResource extends Resource
             DatePicker::make('collected_date')
                 ->label('Data da coleta')
                 ->native(false)
-                ->visible(fn(Get $get) => $get('status') === RegisterStatusEnum::COLLECTED->value)
+                ->visible(fn (Get $get) => $get('status') === RegisterStatusEnum::COLLECTED->value)
                 ->requiredIf('status', RegisterStatusEnum::COLLECTED->value),
             TextInput::make('driver')
                 ->label('Motorista (opcional)')
-                ->visible(fn(Get $get) => $get('status') === RegisterStatusEnum::COLLECTED->value)
+                ->visible(fn (Get $get) => $get('status') === RegisterStatusEnum::COLLECTED->value)
                 ->requiredIf('status', RegisterStatusEnum::COLLECTED->value)
                 ->maxLength(30),
             TextInput::make('driver_plate')
                 ->label('Placa guincho (opcional)')
-                ->visible(fn(Get $get) => $get('status') === RegisterStatusEnum::COLLECTED->value)
+                ->visible(fn (Get $get) => $get('status') === RegisterStatusEnum::COLLECTED->value)
                 ->requiredIf('status', RegisterStatusEnum::COLLECTED->value)
                 ->maxLength(7),
         ];
@@ -417,10 +420,10 @@ class RegisterResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index'  => ListRegisters::route('/'),
+            'index' => ListRegisters::route('/'),
             'create' => CreateRegister::route('/create'),
-            'view'   => ViewRegister::route('/{record}'),
-            'edit'   => EditRegister::route('/{record}/edit'),
+            'view' => ViewRegister::route('/{record}'),
+            'edit' => EditRegister::route('/{record}/edit'),
         ];
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -40,7 +40,7 @@ class AdminPanelProvider extends PanelProvider
                 'available' => Color::hex('#5E07D9'),
                 'invoiced' => Color::hex('#7B57AD'),
                 'waiting' => Color::Gray,
-                'collected' => Color::hex('#07D93A')
+                'collected' => Color::hex('#07D93A'),
             ])
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')

--- a/database/migrations/2025_08_27_210904_update_invoiced_status_to_delivered_in_registers_table.php
+++ b/database/migrations/2025_08_27_210904_update_invoiced_status_to_delivered_in_registers_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('registers')->where('status', 'invoiced')->update(['status' => 'delivered']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('registers')->where('status', 'delivered')->update(['status' => 'invoiced']);
+    }
+};


### PR DESCRIPTION
…matting

- add DELIVERED status to RegisterStatusEnum with proper labels and colors
- create migration to update existing 'invoiced' records to 'delivered' status
- reorder status enum cases for better logical flow
- update table query ordering to use 'delivered' instead of 'invoiced'
- improve table filtering logic for overdue deliveries
- apply consistent code formatting throughout RegisterResource
- fix spacing and alignment in anonymous function declarations
- update sorting to include deadline_withdraw for better organization
- maintain backward compatibility with proper migration rollback