### PR TITLE
fix: increase destination_city field length from 20 to 50 characters

### DIFF
--- a/database/migrations/2025_10_07_161438_change_destination_city_field_length_in_registers_table.php
+++ b/database/migrations/2025_10_07_161438_change_destination_city_field_length_in_registers_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('registers', function (Blueprint $table) {
+            $table->string('destination_city', 50)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('registers', function (Blueprint $table) {
+            $table->string('destination_city', 20)->change();
+        });
+    }
+};


### PR DESCRIPTION
- Add migration to extend destination_city varchar length in registers table
- Resolve potential data truncation issues for longer city names